### PR TITLE
Reorder table subscribe params

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -452,11 +452,14 @@ export class RethinkID {
 
   /**
    * Subscribe to table changes.
+   * @param tableName
+   * @param userId Pass a user ID to operate on a table owned by the corresponding user. Otherwise pass an empty string to operate on a table owned by the authenticated user.
+   * @param listener A callback function to handle table changes.
    */
   async tableSubscribe(
-    listener: (changes: { new_val: object; old_val: object }) => void,
     tableName: string,
-    userId?: string,
+    userId: string,
+    listener: (changes: { new_val: object; old_val: object }) => void,
   ) {
     const { data } = (await this._asyncEmit("table:subscribe", { tableName, userId })) as { data: string }; // data: socket table handle
     const socketTableHandle = data;


### PR DESCRIPTION
This PR reorders the  `tableSubscribe()` params, so that it's nicer to write and read. Having the listener first means it's easier to miss the other params, or more awkward to write them.