### PR TITLE
Put all optional params in an optional options object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -473,15 +473,15 @@ export class RethinkID {
     const payload = { tableName };
     Object.assign(payload, options);
 
-    const response = (await this._asyncEmit("table:subscribe", payload)) as { data: string }; // data: socket table handle
-    const socketTableHandle = response.data;
+    const response = (await this._asyncEmit("table:subscribe", payload)) as { data: string }; // data: subscription handle
+    const subscriptionHandle = response.data;
 
     return {
       do: async (listener: (changes: { new_val: object; old_val: object }) => void) => {
-        socket.on(socketTableHandle, listener);
+        socket.on(subscriptionHandle, listener);
       },
       unsubscribe: async () => {
-        return this._asyncEmit("table:unsubscribe", socketTableHandle) as Promise<{ message: string }>;
+        return this._asyncEmit("table:unsubscribe", subscriptionHandle) as Promise<{ message: string }>;
       },
     };
   }


### PR DESCRIPTION
The PR moves options params, for SDK data API methods, to a single optional `options` object param.

The goal is to avoid having to passing placeholder values where there are multiple optional params (e.g. `permissionsGet(null, null, "read")`), and to make the API more easily extensible.

A second change is to the `tableSubscribe()` method which now returns an `on()` method, as well as a `unsubscribe()` method. The on method now takes a listener callback functions for reacting to tables changes.