### PR TITLE
Refactor tableSubscribe

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -503,6 +503,7 @@ export default class RethinkID {
     socket.on(subscriptionHandle, listener);
 
     return async () => {
+      socket.off(subscriptionHandle, listener);
       return this._asyncEmit("table:unsubscribe", subscriptionHandle) as Promise<{ message: string }>;
     };
   }


### PR DESCRIPTION
Refactors the `tableSubscribe` method to take a `listener` callback param again. To avoid potentially missing message by calling `do` later. And to avoid weirdness of returning two functions.