### PR TITLE
Add `isLoggingIn()` utility method

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Using the bundled file:
 <script>
   const config = {
     appId: "2252e43d-a52f-4964-bf34-9c686726a515",
-    loginRedirectUri: "http://localhost:8080/callback",
+    loginRedirectUri: "http://localhost:8080/complete-login",
   };
 
   const rid = new RethinkID(config);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mostlytyped/rethinkid-js-sdk",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "description": "Conveniently use RethinkID with your app in the browser.",
   "main": "dist/rethinkid-js-sdk.esm.js",
   "typings": "dist/types/index.d.ts",


### PR DESCRIPTION
This avoids an annoying and potentially evasive bug which invalidates a login request.

e.g. A login button could be rendered at a redirect URI view, which would previously set new PKCE values in local storage invalidating the login request.

Also useful if a login redirect URI is not used solely to complete login, e.g. an app's home page, to check when `completeLogin()` needs to be called.

Also piggybacked a small example change `callback` to `complete-login`, because I think it makes more sense and is less vague.