### PR TITLE
Fix types and comments

### DIFF
--- a/src/table/index.ts
+++ b/src/table/index.ts
@@ -16,6 +16,9 @@ export class Table {
     return this.rid.tableRead(this.tableName, { ...this.tableOptions, ...methodOptions });
   }
 
+  /**
+   * @returns An unsubscribe function
+   */
   async subscribe(methodOptions: {} = {}, listener: SubscribeListener) {
     return this.rid.tableSubscribe(this.tableName, { ...this.tableOptions, ...methodOptions }, listener);
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,10 +16,10 @@ export type Options = {
 };
 
 export type Permission = {
-  id: string;
+  id?: string; // for permissionSet ID is present if updating, absent if inserting
   tableName: string;
   userId: string;
-  permission: string;
+  type: "read" | "insert" | "update" | "delete";
   // condition: object; // not yet implemented
 };
 
@@ -43,3 +43,5 @@ export type IdTokenDecoded = {
 };
 
 export type SubscribeListener = (changes: { new_val: object; old_val: object }) => void;
+
+export type MessageOrError = { message?: string; error?: string };


### PR DESCRIPTION
Fixes many many incorrect typings, particularly return types. Adds privacy info to table methods (i.e. if private only, or private by default and otherwise requiring some permissions), otherwise privacy and permissions are a mystery.

**Some thoughts**

A few higher level areas for improvement arose during this work. Comments and types are duplicated in the data api and sdk. That means comments can get out of date/sync. Same with types. That's why these were all inaccurate in the first place.

Also, the sdk's table object doesn't have explicit types or comments, so it's actually nicer to use the separate table methods so you get IntelliSense auto-complete and inline docs.

Adding docs to the sdk table object would triplicate docs and types. Inheriting more from the data api would be much better. I've made a note of this.

Also, having a canonical way to use the SDK (and not the table object or individual table methods) is the way to go I think. One less decision to make, reduces SDK code, removes the need for duplicate docs and types, makes us focus on the one way we want the sdk to be used. I've made a note of this too.