### PR TITLE
Update table to have onCreate function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -647,7 +647,7 @@ export default class RethinkID {
     return this._asyncEmit("table:delete", payload) as Promise<MessageOrError>;
   }
 
-  table(tableName: string, tableOptions: { userId?: string }) {
-    return new Table(this, tableName, tableOptions);
+  table(tableName: string, onCreate: () => Promise<void>, tableOptions?: { userId?: string }) {
+    return new Table(this, tableName, onCreate, tableOptions);
   }
 }

--- a/src/table/index.ts
+++ b/src/table/index.ts
@@ -1,41 +1,74 @@
 import RethinkID from "..";
-import { SubscribeListener } from "../types";
+import { SubscribeListener, MessageOrError } from "../types";
 
 export class Table {
   rid: RethinkID;
   tableName: string;
   tableOptions: { userId?: string };
+  onCreate: () => Promise<void>;
 
-  constructor(rid: RethinkID, tableName: string, tableOptions: { userId?: string }) {
+  constructor(rid: RethinkID, tableName: string, onCreate: () => Promise<void>, tableOptions?: { userId?: string }) {
     this.rid = rid;
     this.tableName = tableName;
     this.tableOptions = tableOptions;
+    this.onCreate = onCreate;
   }
 
   async read(methodOptions: { rowId?: string } = {}) {
-    return this.rid.tableRead(this.tableName, { ...this.tableOptions, ...methodOptions });
+    return this.withTable(this.rid.tableRead(this.tableName, { ...this.tableOptions, ...methodOptions })) as Promise<{
+      data?: object | any[];
+      error?: string;
+    }>;
   }
 
   /**
    * @returns An unsubscribe function
    */
   async subscribe(methodOptions: {} = {}, listener: SubscribeListener) {
-    return this.rid.tableSubscribe(this.tableName, { ...this.tableOptions, ...methodOptions }, listener);
+    return this.withTable(
+      this.rid.tableSubscribe(this.tableName, { ...this.tableOptions, ...methodOptions }, listener),
+    ) as Promise<() => Promise<MessageOrError>>;
   }
 
   async insert(row: object, methodOptions: {} = {}) {
-    return this.rid.tableInsert(this.tableName, row, { ...this.tableOptions, ...methodOptions });
+    return this.withTable(
+      this.rid.tableInsert(this.tableName, row, { ...this.tableOptions, ...methodOptions }),
+    ) as Promise<{
+      data?: string;
+      error?: string;
+    }>;
   }
 
   async update(row: object, methodOptions: {} = {}) {
-    return this.rid.tableUpdate(this.tableName, row, { ...this.tableOptions, ...methodOptions });
+    return this.withTable(
+      this.rid.tableUpdate(this.tableName, row, { ...this.tableOptions, ...methodOptions }),
+    ) as Promise<MessageOrError>;
   }
 
   async replace(methodOptions: {} = {}) {
-    return this.rid.tableReplace(this.tableName, { ...this.tableOptions, ...methodOptions });
+    return this.withTable(
+      this.rid.tableReplace(this.tableName, { ...this.tableOptions, ...methodOptions }),
+    ) as Promise<MessageOrError>;
   }
 
   async delete(methodOptions: { rowId?: string } = {}) {
-    return this.rid.tableDelete(this.tableName, { ...this.tableOptions, ...methodOptions });
+    return this.withTable(
+      this.rid.tableDelete(this.tableName, { ...this.tableOptions, ...methodOptions }),
+    ) as Promise<MessageOrError>;
+  }
+
+  //
+  async withTable(tableQuery: Promise<any>) {
+    let result = await tableQuery;
+    // Table `af450dd0-88ad-4f15-ac24-7e4aef4ddec9_7cb5a8f3-c174-4f12-aa72-d188a89ccae9.hosted_games` does not exist in:
+    if (result.error && result.error.match(/Table `.*` does not exist in/)) {
+      const createRes = await this.rid.tablesCreate(this.tableName);
+      if (createRes.error) {
+        return createRes;
+      }
+      await this.onCreate();
+      return tableQuery;
+    }
+    return result;
   }
 }


### PR DESCRIPTION
Update the table class to be able to auto-create a table and run a proper `onCreate` function. This helps to reduce code duplication as the user no longer has to check if a table exists everywhere it is used.

Goes in hand with https://github.com/mostlytyped/rethink-identity/pull/56