### PR TITLE
Allow setting options after initialisation

### DIFF
--- a/src/api/raw.ts
+++ b/src/api/raw.ts
@@ -142,6 +142,18 @@ export class API {
     });
   };
 
+  /**
+   * Set options after an API instance is initialized
+   */
+  setOptions(options: { onConnect?: () => void; onConnectError?: (message: string) => void }) {
+    if (options.onConnect) {
+      this.onConnect = options.onConnect;
+    }
+    if (options.onConnectError) {
+      this.onConnectError = options.onConnectError;
+    }
+  }
+
   //
   // Collection API
   //

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,28 @@ export class RethinkID {
     this.social = new SocialAPI(this.api);
   }
 
+  /**
+   * Set options after an SDK instance is initialized
+   */
+  setOptions(options: {
+    onLogin?: (rid: RethinkID) => Promise<void>;
+    onApiConnect?: (rid: RethinkID) => void;
+    onApiConnectError?: (rid: RethinkID, message: string) => void;
+  }) {
+    if (options.onLogin) {
+      this.onLogin(options.onLogin);
+    }
+
+    const apiOptions: { onConnect?: () => void; onConnectError?: (message: string) => void } = {};
+    if (options.onApiConnect) {
+      apiOptions.onConnect = () => options.onApiConnect(this);
+    }
+    if (options.onApiConnectError) {
+      apiOptions.onConnectError = (message: string) => options.onApiConnectError(this, message);
+    }
+    this.api.setOptions(apiOptions);
+  }
+
   //
   // Login methods
   //


### PR DESCRIPTION
This allows setting `onLogin`, `onApiConnect`, and `onApiConnectError` callbacks after the SDK is initialised. So, now these options can be set in the SDK `constructor`, or via the new `setOptions` method.

Use case:

Your app works offline. On reconnection, after being offline, you want to sync changes. For a Vue.js app, using a Pinia store, it would be very cumbersome to set an `onApiConnect` callback in the SDK constructor. Likely in that case a Pinia store would need to be imported to the module initializing the SDK, and likely that Pinia store would itself import the SDK instance being currently initalised, giving an error like `Cannot access 'rid' before initialization`. 

Instead, setting the callback in the context that makes most sense is very convenient.