### PR TITLE
Improve Login Errors

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -122,6 +122,19 @@ export class Auth {
         return resolve();
       }
 
+      /**
+       * Stop a log in request early when it cannot succeed to avoid a potentially frustrating DX.
+       * The same check happens later in the log in process in {@link receiveLoginWindowMessage} for security.
+       */
+      if (window.origin !== this.baseUrl) {
+        reject(
+          new Error(
+            `Login failed: Request origin (${window.origin}) doesn't match configured loginRedirectUri origin (${this.baseUrl})`,
+          ),
+        );
+        return;
+      }
+
       const windowName = "rethinkid-login-window";
 
       // Add the listener for receiving a message from the pop-up


### PR DESCRIPTION
1. Make sure errors that occur in the opener window, when a message is received from the pop-up in `receiveLoginWindowMessage`, propagate to the `rid.login` method initially called.
2. Piggyback cleaning up the related `message` event listener.
3. Add a check ASAP that stops login request where the request origin doesn't match the `loginRedirectUri` origin. Such a request can't succeed, no need to go through the whole login process only for it to fail right at the end. Also, in this case, it will fail silently, because the `postMessage` target origin will not match and so will not fire. No error, just silent confusion.