### PR TITLE
Check login origins before redirect

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -179,7 +179,6 @@ export class Auth {
           // App explicitly does not want to fallback to redirect
           reject(new Error("Pop-up failed to open"));
         } else {
-          console.log("fallback to redirect");
           // Fallback to redirect login
           window.location.href = url;
           return resolve();


### PR DESCRIPTION
Check origins before any login type, redirect or pop-up. The origins need to match for redirect login to succeed too.