### PR TITLE
Better options intellisense

### DIFF
--- a/src/api/raw.ts
+++ b/src/api/raw.ts
@@ -1,7 +1,7 @@
 import io from "socket.io-client";
 
 import {
-  CommonOptions,
+  APIOptions,
   Permission,
   NewPermission,
   SubscribeListener,
@@ -61,7 +61,7 @@ export class API {
   private iframe: HTMLIFrameElement;
 
   constructor(
-    options: CommonOptions,
+    options: APIOptions,
     onConnect: () => Promise<void>,
     onConnectError: (message: string) => Promise<void>,
   ) {

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,6 +1,6 @@
 import { OAuth2Client, OAuth2Token, generateCodeVerifier } from "@badgateway/oauth2-client";
 
-import { CommonOptions, AuthOptions, LoginType } from "../types";
+import { AuthOptions, LoginType } from "../types";
 import { generateRandomString, popupWindow } from "../utils";
 import { namespacePrefix } from "../constants";
 
@@ -73,7 +73,7 @@ export class Auth {
    */
   onLoginError: (message: string) => void;
 
-  constructor(options: CommonOptions & AuthOptions, onLogin: () => void, onLoginError: (message: string) => void) {
+  constructor(options: AuthOptions, onLogin: () => void, onLoginError: (message: string) => void) {
     this.onLogin = onLogin;
 
     this.onLoginError = onLoginError;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { PermissionsAPI } from "./api/permissions";
 import { SocialAPI } from "./api/social";
 import { Auth } from "./auth";
 import { rethinkIdUri } from "./constants";
-import { AuthOptions, CollectionOptions, CommonOptions, Doc, LoginType } from "./types";
+import { RethinkIDOptions, CollectionOptions, Doc, LoginType } from "./types";
 
 /**
  * Types of errors that can return from the API
@@ -33,37 +33,8 @@ export {
   Doc,
   AnyDoc,
   SubscribeListener,
+  RethinkIDOptions
 } from "./types";
-
-/**
- * RethinkID constructor options
- */
-export type Options = CommonOptions &
-  AuthOptions & {
-    /**
-     * Provide a callback to handle a successful login.
-     *
-     * e.g. Set state, redirect, etc.
-     */
-    onLogin?: (rid: RethinkID) => Promise<void>;
-
-    /**
-     * Provide a callback to handle a failed login. E.g. invalid authorization code.
-     *
-     * e.g. Set state, redirect, etc.
-     */
-    onLoginError?: (rid: RethinkID, message: string) => Promise<void>;
-
-    /**
-     * Provide a callback to handle API connections. Will be called after login and any subsequent re-connection.
-     */
-    onApiConnect?: (rid: RethinkID) => Promise<void>;
-
-    /**
-     * Provide a callback to handle failed data API connections. E.g. unauthorized, or expired token.
-     */
-    onApiConnectError?: (rid: RethinkID, message: string) => Promise<void>;
-  };
 
 /**
  * The primary class of the RethinkID JS SDK to help you more easily build web apps with RethinkID.
@@ -95,7 +66,7 @@ export class RethinkID {
    */
   social: SocialAPI;
 
-  constructor(options: Options) {
+  constructor(options: RethinkIDOptions) {
     if (!options.rethinkIdUri) {
       options.rethinkIdUri = rethinkIdUri;
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,21 +1,48 @@
+import { RethinkID } from "..";
+
 /**
- * RethinkID constructor options
+ * Options for initializing a RethinkID instance
  */
-export type CommonOptions = {
+export type RethinkIDOptions = {
   appId: string;
   /**
-   * Public URI for the API & OAuth authorization server.
-   * Will set AuthOptions.oAuthUri & ApiOptions.dataApiUri
+   * Public URI for the API & OAuth server.
    */
   rethinkIdUri?: string;
-};
-
-export type AuthOptions = {
+  
   /**
-   * The URI the auth server redirects to with an auth code, after successful approving a login request.
+   * The URI the auth server redirects to with an auth code after login request approval.
    */
   loginRedirectUri: string;
-};
+
+  /**
+   * Provide a callback to handle a successful login.
+   *
+   * e.g. Set state, redirect, etc.
+   */
+  onLogin?: (rid: RethinkID) => Promise<void>;
+
+  /**
+   * Provide a callback to handle a failed login. E.g. invalid authorization code.
+   *
+   * e.g. Set state, redirect, etc.
+   */
+  onLoginError?: (rid: RethinkID, message: string) => Promise<void>;
+
+  /**
+   * Provide a callback to handle API connections. Will be called after login and any subsequent re-connection.
+   */
+  onApiConnect?: (rid: RethinkID) => Promise<void>;
+
+  /**
+   * Provide a callback to handle failed data API connections. E.g. unauthorized, or expired token.
+   */
+  onApiConnectError?: (rid: RethinkID, message: string) => Promise<void>;
+}
+
+export type AuthOptions = Omit<RethinkIDOptions, "onLogin" | "onLoginError" | "onApiConnect" | "onApiConnectError">;
+
+export type APIOptions = Omit<AuthOptions, "loginRedirectUri">;
 
 /**
  * Represents a complete permission object which includes both the `id` field and `userId` for user association.


### PR DESCRIPTION
This PR re-writes the various constructor option types using Omit for better intellisense readbility.

Previously the intellisense type for the RethinkID class options looked like this (notice CommonOptions and AuthOptions are not visible:

```ts
(alias) type Options = CommonOptions & AuthOptions & {
    onLogin?: ((rid: RethinkID) => Promise<void>) | undefined;
    onLoginError?: ((rid: RethinkID, message: string) => Promise<void>) | undefined;
    onApiConnect?: ((rid: RethinkID) => Promise<void>) | undefined;
    onApiConnectError?: ((rid: RethinkID, message: string) => Promise<void>) | undefined;
}
```

Now it looks like this:

```ts
(alias) type RethinkIDOptions = {
    appId: string;
    rethinkIdUri?: string | undefined;
    loginRedirectUri: string;
    onLogin?: ((rid: RethinkID) => Promise<void>) | undefined;
    onLoginError?: ((rid: RethinkID, message: string) => Promise<void>) | undefined;
    onApiConnect?: ((rid: RethinkID) => Promise<void>) | undefined;
    onApiConnectError?: ((rid: RethinkID, message: string) => Promise<void>) | undefined;
}
```
