### PR TITLE
Notifications

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@mostlytyped:registry=https://npm.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![NPM Version](https://img.shields.io/npm/v/bzr/bazaar-js.svg?style=flat)](https://www.npmjs.com/package/@bzr/bazaar)
+[![NPM Version](https://img.shields.io/npm/v/bzr/bazaar.svg?style=flat)](https://www.npmjs.com/package/@bzr/bazaar)
 [![NPM License](https://img.shields.io/npm/l/all-contributors.svg?style=flat)](https://github.com/bzr-sys/bazaar-js/blob/master/LICENSE)
 
 # The Bazaar JavaScript SDK

--- a/src/api/notifications.ts
+++ b/src/api/notifications.ts
@@ -1,5 +1,4 @@
-import { linkPath, bazaarUri } from "../constants";
-import { type SubscribeListener, NotificationTemplate, Notification } from "../types";
+import { type SubscribeListener, CreateNotification, Notification } from "../types";
 import { API } from "./raw";
 
 /**
@@ -16,7 +15,7 @@ export class NotificationsAPI {
   /**
    * Creates notification for a target user.
    */
-  async create(notification: NotificationTemplate) {
+  async create(notification: CreateNotification) {
     return this.api.notificationsCreate(notification);
   }
 
@@ -24,13 +23,28 @@ export class NotificationsAPI {
    * Lists notifications.
    * @returns All notifications for this app and user
    */
-  async list() {
-    const res = await this.api.notificationsList();
+  async list(
+    options: {
+      includeHidden?: boolean;
+      senderId?: string;
+      startTs?: Date;
+      endTs?: Date;
+    } = {},
+  ) {
+    const res = await this.api.notificationsList(options);
     return res.data;
   }
 
-  async subscribe(listener: SubscribeListener<Notification>) {
-    return this.api.notificationsSubscribe(listener);
+  async subscribe(
+    options: {
+      includeHidden?: boolean;
+      senderId?: string;
+      startTs?: Date;
+      endTs?: Date;
+    } = {},
+    listener: SubscribeListener<Notification>,
+  ) {
+    return this.api.notificationsSubscribe(options, listener);
   }
 
   /**
@@ -38,7 +52,7 @@ export class NotificationsAPI {
    * @param notificationId - ID of the notification to hide
    */
   async hide(notificationId: string) {
-    return this.api.notificationsHide(permissionId);
+    return this.api.notificationsHide(notificationId);
   }
 
   /**
@@ -46,6 +60,6 @@ export class NotificationsAPI {
    * @param notificationId - ID of the notification to delete
    */
   async delete(notificationId: string) {
-    return this.api.notificationsDelete(permissionId);
+    return this.api.notificationsDelete(notificationId);
   }
 }

--- a/src/api/notifications.ts
+++ b/src/api/notifications.ts
@@ -1,0 +1,51 @@
+import { linkPath, bazaarUri } from "../constants";
+import { type SubscribeListener, NotificationTemplate, Notification } from "../types";
+import { API } from "./raw";
+
+/**
+ * The class that encapsulates the notification API
+ * @internal
+ */
+export class NotificationsAPI {
+  private api: API;
+
+  constructor(api: API) {
+    this.api = api;
+  }
+
+  /**
+   * Creates notification for a target user.
+   */
+  async create(notification: NotificationTemplate) {
+    return this.api.notificationsCreate(notification);
+  }
+
+  /**
+   * Lists notifications.
+   * @returns All notifications for this app and user
+   */
+  async list() {
+    const res = await this.api.notificationsList();
+    return res.data;
+  }
+
+  async subscribe(listener: SubscribeListener<Notification>) {
+    return this.api.notificationsSubscribe(listener);
+  }
+
+  /**
+   * Hides notification with a given ID
+   * @param notificationId - ID of the notification to hide
+   */
+  async hide(notificationId: string) {
+    return this.api.notificationsHide(permissionId);
+  }
+
+  /**
+   * Deletes notification with a given ID
+   * @param notificationId - ID of the notification to delete
+   */
+  async delete(notificationId: string) {
+    return this.api.notificationsDelete(permissionId);
+  }
+}

--- a/src/api/permissions.ts
+++ b/src/api/permissions.ts
@@ -90,6 +90,10 @@ export class PermissionsAPI {
       return links;
     },
 
+    /**
+     * Subscribes to links changes
+     * @returns an unsubscribe function
+     */
     subscribe: async (
       options: {
         collectionName?: string;
@@ -111,7 +115,7 @@ export class PermissionsAPI {
     },
 
     /**
-     * Deletes permissions for a table
+     * Deletes a link
      */
     delete: async (linkId: string) => {
       return this.api.linksDelete(linkId);

--- a/src/api/permissions.ts
+++ b/src/api/permissions.ts
@@ -1,13 +1,14 @@
 import { linkPath, bazaarUri } from "../constants";
-import type {
-  BasicLink,
-  GrantedPermission,
-  Link,
-  NewPermission,
-  Notification,
-  PermissionTemplate,
-  PermissionType,
-  SubscribeListener,
+import {
+  SendNotification,
+  type BasicLink,
+  type GrantedPermission,
+  type Link,
+  type NewPermission,
+  type PermissionTemplate,
+  type PermissionType,
+  type SharingNotification,
+  type SubscribeListener,
 } from "../types";
 import { API } from "./raw";
 
@@ -25,9 +26,14 @@ export class PermissionsAPI {
   }
 
   /**
-   * Creates permission for a collection.
+   * Creates permission for a collection query and a user.
+   * @param {NewPermission} permission "Specifies the permission to be created"
+   * @param {SharingNotification} notification "Specifies if/how the user is notified. Defaults to {createNotification: false, sendMessage: SendNotification.Never}"
    */
-  async create(permission: NewPermission, notification: Notification = { enabled: false }) {
+  async create(
+    permission: NewPermission,
+    notification: SharingNotification = { createNotification: false, sendMessage: SendNotification.NEVER },
+  ) {
     return this.api.permissionsCreate(permission, notification);
   }
 

--- a/src/api/raw.ts
+++ b/src/api/raw.ts
@@ -4,7 +4,6 @@ import type {
   APIOptions,
   Permission,
   NewPermission,
-  Notification,
   SubscribeListener,
   BazaarMessage,
   Contact,
@@ -17,6 +16,9 @@ import type {
   CollectionCommonOptions,
   CollectionGetAllOptions,
   CollectionCommonAllOptions,
+  SharingNotification,
+  Notification,
+  CreateNotification,
 } from "../types";
 import { BazaarError } from "../utils";
 import { bazaarUri, namespacePrefix } from "../constants";
@@ -406,8 +408,7 @@ export class API {
   /**
    * Creates a permission.
    */
-  async permissionsCreate(permission: NewPermission, notification: Notification) {
-    console.log("this", this);
+  async permissionsCreate(permission: NewPermission, notification: SharingNotification) {
     return this.asyncEmit(this.version + ":permissions:create", { permission, notification }) as Promise<{
       id: string;
     }>;
@@ -426,7 +427,6 @@ export class API {
    * Creates a permission link.
    */
   async linksCreate(permission: PermissionTemplate, limit: number = 0) {
-    console.log("this", this);
     return this.asyncEmit(this.version + ":links:create", { permission, limit }) as Promise<{ data: BasicLink }>;
   }
 
@@ -534,6 +534,77 @@ export class API {
   async grantedPermissionsDelete(grantedPermissionId: string) {
     const payload = { grantedPermissionId };
     return this.asyncEmit(this.version + ":granted_permissions:delete", payload) as Promise<BazaarMessage>;
+  }
+
+  //
+  // Notifications API
+  //
+
+  /**
+   * Creates a notification.
+   */
+  async notificationsCreate(notification: CreateNotification) {
+    return this.asyncEmit(this.version + ":notifications:create", { notification }) as Promise<{ data: Notification }>;
+  }
+
+  /**
+   * Lists notifications.
+   *
+   * @param options - If no options are set, all non-hidden notifications are returned.
+   * @returns Where `data` is an array of notifications
+   */
+  async notificationsList(
+    options: {
+      includeHidden?: boolean;
+      senderId?: string;
+      startTs?: Date;
+      endTs?: Date;
+    } = {},
+  ) {
+    return this.asyncEmit(this.version + ":notifications:list", options) as Promise<{ data: Notification[] }>;
+  }
+
+  /**
+   * Subscribes to notification changes
+   *
+   * @param options -
+   * @param listener - The callback function that receives notification change events.
+   * @returns An unsubscribe function
+   */
+  async notificationsSubscribe(
+    options: {
+      includeHidden?: boolean;
+      senderId?: string;
+      startTs?: Date;
+      endTs?: Date;
+    } = {},
+    listener: SubscribeListener<Notification>,
+  ) {
+    const response = (await this.asyncEmit(this.version + ":notifications:subscribe", options)) as {
+      data: string;
+    }; // where data is the subscription handle
+    const subscriptionHandle = response.data;
+
+    this.dataApi.on(subscriptionHandle, listener);
+
+    return async () => {
+      this.dataApi.off(subscriptionHandle, listener);
+      return this.asyncEmit(this.version + ":notifications:unsubscribe", subscriptionHandle) as Promise<BazaarMessage>;
+    };
+  }
+
+  /**
+   * Hides notifications.
+   */
+  async notificationsHide(notificationId: string) {
+    return this.asyncEmit(this.version + ":notifications:hide", { notificationId }) as Promise<BazaarMessage>;
+  }
+
+  /**
+   * Deletes notifications.
+   */
+  async notificationsDelete(notificationId: string) {
+    return this.asyncEmit(this.version + ":notifications:delete", { notificationId }) as Promise<BazaarMessage>;
   }
 
   //

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { SocialAPI } from "./api/social";
 import { Auth } from "./auth";
 import { bazaarUri } from "./constants";
 import type { BazaarOptions, CollectionOptions, Doc, LoginType } from "./types";
+import { NotificationsAPI } from "./api/notifications";
 
 /**
  * Types of errors that can return from the API
@@ -28,6 +29,8 @@ export type {
   NewPermission,
   PermissionTemplate,
   GrantedPermission,
+  SendNotification,
+  SharingNotification,
   FilterObject,
   FilterComparison,
   OrderBy,
@@ -64,6 +67,12 @@ export class BazaarApp {
    * Access to the permissions API
    */
   permissions: PermissionsAPI;
+
+  /**
+   * Access to the notifications API
+   * @alpha
+   */
+  private notifications: NotificationsAPI;
 
   /**
    * Access to the social API
@@ -116,6 +125,7 @@ export class BazaarApp {
 
     this.collections = new CollectionsAPI(this.api);
     this.permissions = new PermissionsAPI(this.api, options.bazaarUri);
+    this.notifications = new NotificationsAPI(this.api);
     this.social = new SocialAPI(this.api);
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -117,8 +117,22 @@ export type SharingNotification = {
  * @beta
  */
 export type Notification = {
-  enabled: boolean;
-  message?: string;
+  id: string;
+  //userId: string;
+  //appId: string;
+  senderId: string;
+
+  message: string;
+  hidden: boolean;
+};
+
+/**
+ *
+ */
+export type NotificationTemplate = {
+  userId: string;
+  sendMessage?: SendNotification; // Defaults to never
+  message: string;
 };
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -114,25 +114,25 @@ export type SharingNotification = {
 };
 
 /**
- * @beta
+ *
  */
 export type Notification = {
   id: string;
   //userId: string;
   //appId: string;
   senderId: string;
-
   message: string;
+  ts: Date;
   hidden: boolean;
 };
 
 /**
  *
  */
-export type NotificationTemplate = {
+export type CreateNotification = {
   userId: string;
   sendMessage?: SendNotification; // Defaults to never
-  message: string;
+  message: string; // max 250 chars
 };
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -84,6 +84,36 @@ export enum PermissionType {
 }
 
 /**
+ * Represents the options for sending notifications.
+ */
+export enum SendNotification {
+  /**
+   * Send an invitation if the target user does not use the app
+   */
+  INVITE_ONLY = "invite-only",
+  /**
+   * Always send an invitation to the target user
+   */
+  ALWAYS = "always",
+  /**
+   * Never send an invitation to the target user
+   */
+  NEVER = "never",
+}
+
+/**
+ *
+ */
+export type SharingNotification = {
+  createNotification: boolean;
+  sendMessage: SendNotification;
+  /**
+   * Defaults to "X shared something with you in app Y"
+   */
+  message?: string;
+};
+
+/**
  * @beta
  */
 export type Notification = {


### PR DESCRIPTION
This PR is more of a proposal than actual functionality.

The first commit shows the improved notification for the permission create API. If `createNotification` is set to true, it would create an entry in a Bazaar notification table for the recipient of the permission. We can then show these notifications on the Bazaar dashboard. This is basically what we discussed on the last call.

Given that we need such a notification table, I proposed a notification API in the second commit that allows for creating, handling, and listing notifications directly. I dont know if it is a good idea as I have trouble gauging its usefulness and am unsure if we could open the door for notification spamming. What do you think, @paddyohanlon @alevy?