### PR TITLE
Add checks for common errors

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -29,6 +29,14 @@ export class BazaarError extends Error {
   }
 }
 
+export function isNoAppUserError(e: Error) {
+  return e instanceof BazaarError && e.type === ErrorTypes.DatabaseDoesNotExist;
+}
+
+export function isNoPermissionError(e: Error) {
+  return e instanceof BazaarError && e.type === ErrorTypes.NoPermission;
+}
+
 /**
  * Generates a secure random string using the browser crypto functions
  */


### PR DESCRIPTION
What do you think about those?

I feel like `isNoAppUserError` is kind of useful since it is a check we actually want to perform and `DatabaseDoesNotExist` is not very clear, i.e., it is not clear to an average developer why that means that the user is not using this particular app.

I added the ` isNoPermissionError` for good measure since I assumed those two will be the most common errors we want to explicitly handle.