### PR TITLE
Check for Data API

### DIFF
--- a/src/api/raw.ts
+++ b/src/api/raw.ts
@@ -128,6 +128,10 @@ export class API {
    * Makes sure a connection to the Data API has been made.
    */
   private waitForConnection: () => Promise<true> = () => {
+    if (!this.dataApi) {
+      return Promise.reject(new Error("Uninitialized data API. Possible unauthenticated request"));
+    }
+
     return new Promise((resolve, reject) => {
       if (this.dataApi.connected) {
         resolve(true);


### PR DESCRIPTION
If an unauthenticated request is made to the data API, the following error is seen in the console:

`TypeError: Cannot read properties of undefined (reading 'connected')`

That's because the data API is only initialised if an auth token is present.

Handle this scenario with a clearer error message.