### PR TITLE
Deep Partial

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to npmjs
+name: Publish to NPM
 on:
   release:
     types: [created]
@@ -9,8 +9,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -8,6 +8,7 @@ import type {
   Doc,
   AnyDoc,
   MirrorOptions,
+  DeepPartial,
 } from "../types";
 import { ErrorTypes, BazaarError } from "../utils";
 
@@ -138,7 +139,7 @@ export class CollectionAPI<T extends Doc = AnyDoc> {
     }) as Promise<string>;
   }
 
-  async updateOne(docId: string, doc: Partial<T>) {
+  async updateOne(docId: string, doc: DeepPartial<T>) {
     return this.withCollection(() =>
       this.api.collectionUpdateOne(this.collectionName, docId, doc, this.collectionOptions),
     ) as Promise<BazaarMessage>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export type {
   Link,
   Doc,
   AnyDoc,
+  DeepPartial,
   SubscribeListener,
   BazaarOptions,
   MirrorOptions,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -190,6 +190,14 @@ export type AnyDoc = Doc & {
   [key: string | number | symbol]: any;
 };
 
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends (infer U)[]
+    ? DeepPartial<U>[]
+    : T[P] extends object | undefined
+    ? DeepPartial<T[P]>
+    : T[P];
+};
+
 /**
  *
  */


### PR DESCRIPTION
Partial types in TypeScript only work on the first level of an object. Update types can be recursively partial. This PR introduces a DeepPartial type.