### PR TITLE
Use js catch type (unknown) for error checks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { NotificationsAPI } from "./api/notifications";
 /**
  * Types of errors that can return from the API
  */
-export { ErrorTypes, BazaarError } from "./utils";
+export { ErrorTypes, BazaarError, isNoAppUserError, isNoPermissionError } from "./utils";
 export { CollectionAPI } from "./api/collection";
 export { CollectionsAPI } from "./api/collections";
 export { PermissionsAPI } from "./api/permissions";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -29,11 +29,11 @@ export class BazaarError extends Error {
   }
 }
 
-export function isNoAppUserError(e: Error) {
+export function isNoAppUserError(e: unknown) {
   return e instanceof BazaarError && e.type === ErrorTypes.DatabaseDoesNotExist;
 }
 
-export function isNoPermissionError(e: Error) {
+export function isNoPermissionError(e: unknown) {
   return e instanceof BazaarError && e.type === ErrorTypes.NoPermission;
 }
 


### PR DESCRIPTION
Avoids casting or checking before using these functions.