### PR TITLE
Use a GitHub Action to generate docs with TypeDoc and create a website PR

### DIFF
--- a/.github/workflows/update-api-reference.yml
+++ b/.github/workflows/update-api-reference.yml
@@ -77,4 +77,4 @@ jobs:
           cd website
           gh pr create --title "Update TypeDoc generated API reference" --body "This PR updates the API Reference for the project." --head update-generated-reference --base main
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/update-api-reference.yml
+++ b/.github/workflows/update-api-reference.yml
@@ -1,0 +1,66 @@
+# on merge to main
+# run `typedoc ./src/index.ts --out ./typedoc-temp`
+# checkout website repo
+# create branch update-generated-reference
+# copy ./typedoc-temp to website:./api
+# commit "Update TypeDoc generated API reference"
+# push?
+# create PR "Update TypeDoc generated API reference"
+
+name: Update API Reference
+
+on:
+  push:
+    # branches:
+    #   - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate TypeDoc Reference
+        run: |
+          npm install
+          npx typedoc ./src/index.ts --out ./typedoc-temp
+
+      - name: Checkout Website Repository
+        uses: actions/checkout@v4
+        with:
+          repository: "bzr-sys/bazaar-website"
+          token: ${{ secrets.ACCESS_TOKEN }}
+          path: "website"
+
+      - name: Create New Branch
+        run: |
+          cd website
+          git checkout -b update-generated-reference
+
+      - name: Copy Reference to Website
+        run: |
+          cp -R ../typedoc-temp/* ./api/
+
+      - name: Commit Changes
+        run: |
+          cd website
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add ./api
+          git commit -m "Update TypeDoc generated API reference"
+
+      - name: Push Changes
+        run: |
+          cd website
+          git push origin update-generated-reference
+
+      - name: Create Pull Request
+        run: |
+          cd website
+          gh pr create --title "Update TypeDoc generated API reference" --body "This PR updates the API Reference for the project." --head update-generated-reference --base main

--- a/.github/workflows/update-api-reference.yml
+++ b/.github/workflows/update-api-reference.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Copy Reference to Website
         run: |
-          cp -R ../typedoc-temp/* ./api/
+          cp -R typedoc-temp/. website/api/
 
       - name: Commit Changes
         run: |

--- a/.github/workflows/update-api-reference.yml
+++ b/.github/workflows/update-api-reference.yml
@@ -31,6 +31,9 @@ jobs:
           npm install
           npx typedoc ./src/index.ts --out ./typedoc-temp
 
+      - name: List output of typedoc
+        run: ls -la typedoc-temp
+
       - name: Checkout Website Repository
         uses: actions/checkout@v4
         with:
@@ -42,6 +45,11 @@ jobs:
         run: |
           cd website
           git checkout -b update-generated-reference
+
+      - name: Show current directory and list contents
+        run: |
+          pwd
+          ls -la
 
       - name: Copy Reference to Website
         run: |

--- a/.github/workflows/update-api-reference.yml
+++ b/.github/workflows/update-api-reference.yml
@@ -41,10 +41,14 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           path: "website"
 
-      - name: Create New Branch
+      - name: Create or Reset Branch
         run: |
           cd website
+          git fetch
+          git checkout main
+          git branch -D update-generated-reference || true  # Delete if exists, ignore error if not
           git checkout -b update-generated-reference
+          git push -u origin update-generated-reference --force
 
       - name: Show current directory and list contents
         run: |

--- a/.github/workflows/update-api-reference.yml
+++ b/.github/workflows/update-api-reference.yml
@@ -72,3 +72,5 @@ jobs:
         run: |
           cd website
           gh pr create --title "Update TypeDoc generated API reference" --body "This PR updates the API Reference for the project." --head update-generated-reference --base main
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update-api-reference.yml
+++ b/.github/workflows/update-api-reference.yml
@@ -1,18 +1,9 @@
-# on merge to main
-# run `typedoc ./src/index.ts --out ./typedoc-temp`
-# checkout website repo
-# create branch update-generated-reference
-# copy ./typedoc-temp to website:./api
-# commit "Update TypeDoc generated API reference"
-# push?
-# create PR "Update TypeDoc generated API reference"
-
 name: Update API Reference
 
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
 
 permissions:
   contents: write
@@ -75,6 +66,6 @@ jobs:
       - name: Create Pull Request
         run: |
           cd website
-          gh pr create --title "Update TypeDoc generated API reference" --body "This PR updates the API Reference for the project." --head update-generated-reference --base main
+          gh pr create --title "(Auto-generated PR) Update TypeDoc generated API reference" --body "This PR was created by a GitHub Action in the `bzr-sys/bazaar-js` repo. An API reference is generated using TypeDoc and committed in this PR." --head update-generated-reference --base main
         env:
           GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist
 node_modules
+typedoc-temp
 
 # OS Specific Files
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "rollup-plugin-polyfill-node": "^0.12.0",
         "rollup-plugin-typescript2": "^0.36.0",
         "tslib": "^2.3.1",
+        "typedoc": "^0.25.13",
         "typescript": "^5.2.2"
       },
       "engines": {
@@ -1149,6 +1150,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
+      "dev": true
+    },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -2227,6 +2234,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -2305,6 +2318,12 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/magic-string": {
       "version": "0.30.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
@@ -2330,6 +2349,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/merge2": {
@@ -2881,6 +2912,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3076,6 +3119,51 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.25.13",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.13.tgz",
+      "integrity": "sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.3",
+        "shiki": "^0.14.7"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
@@ -3142,6 +3230,18 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "rollup-plugin-polyfill-node": "^0.12.0",
     "rollup-plugin-typescript2": "^0.36.0",
     "tslib": "^2.3.1",
+    "typedoc": "^0.25.13",
     "typescript": "^5.2.2"
   },
   "dependencies": {

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "navigationLinks": {
+    "Docs": "https://bzr.dev/docs/"
+  }
+}


### PR DESCRIPTION
This PR installs TypeDoc for generating an API reference.

A GitHub Action, then generates the docs, checks out the website repo and creates a PR with the generated docs (on push to `main`)

The GitHub Action relies on a classic personal access token (PAT) with `repo` permissions. A GitHub App seems to be the better solution, but for now it was enough of a headache to get things working with the PAT.