### PR TITLE
Replace alpha mirrorAll with onInitial in SubscribeListener

### DIFF
--- a/src/api/notifications.ts
+++ b/src/api/notifications.ts
@@ -44,6 +44,12 @@ export class NotificationsAPI {
     } = {},
     listener: SubscribeListener<Notification>,
   ) {
+    if (listener.onInitial) {
+      const notifications = await this.list(options);
+      for (const notification of notifications) {
+        listener.onInitial(notification);
+      }
+    }
     return this.api.notificationsSubscribe(options, listener);
   }
 

--- a/src/api/permissions.ts
+++ b/src/api/permissions.ts
@@ -101,6 +101,13 @@ export class PermissionsAPI {
       } = {},
       listener: SubscribeListener<Link>,
     ) => {
+      if (listener.onInitial) {
+        const links = await this.links.list(options);
+        for (const link of links) {
+          listener.onInitial({ url: this.linkUri + link.id, ...link });
+        }
+      }
+
       const newListener: SubscribeListener<BasicLink> = {};
       if (listener.onAdd) {
         newListener.onAdd = (doc) => {
@@ -156,6 +163,12 @@ export class PermissionsAPI {
       } = {},
       listener: SubscribeListener<GrantedPermission>,
     ) => {
+      if (listener.onInitial) {
+        const permissions = await this.granted.list(options);
+        for (const permission of permissions) {
+          listener.onInitial(permission);
+        }
+      }
       return this.api.grantedPermissionsSubscribe(options, listener);
     },
   };

--- a/src/api/social.ts
+++ b/src/api/social.ts
@@ -51,6 +51,12 @@ export class SocialAPI {
      * @returns an unsubscribe function
      */
     subscribe: async (listener: SubscribeListener<Contact>) => {
+      if (listener.onInitial) {
+        const contacts = await this.contacts.list();
+        for (const contact of contacts) {
+          listener.onInitial(contact);
+        }
+      }
       return this.api.contactsSubscribe(listener);
     },
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,14 @@ import { NotificationsAPI } from "./api/notifications";
 /**
  * Types of errors that can return from the API
  */
-export { ErrorTypes, BazaarError, isNoAppUserError, isNoPermissionError } from "./utils";
+export {
+  ErrorTypes,
+  BazaarError,
+  isNoAppUserError,
+  isNoPermissionError,
+  arrayMirrorSubscribeListener,
+  objectMirrorSubscribeListener,
+} from "./utils";
 export { CollectionAPI } from "./api/collection";
 export { CollectionsAPI } from "./api/collections";
 export { PermissionsAPI } from "./api/permissions";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -84,15 +84,16 @@ export enum PermissionType {
  */
 export enum SendNotification {
   /**
-   * Send an invitation if the target user does not use the app
+   * Send an notification if the target user does not use the app.
+   * This is akin to inviting the target user to use the app.
    */
   INVITE_ONLY = "invite-only",
   /**
-   * Always send an invitation to the target user
+   * Always send an notification to the target user
    */
   ALWAYS = "always",
   /**
-   * Never send an invitation to the target user
+   * Never send an notification to the target user
    */
   NEVER = "never",
 }
@@ -210,6 +211,7 @@ export type SubscribeListener<T extends Doc> = {
   onAdd?: (doc: T) => void;
   onChange?: (oldDoc: T, newDoc: T) => void;
   onDelete?: (doc: T) => void;
+  onInitial?: (doc: T) => void;
 };
 
 /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,5 @@
+import type { Doc, SubscribeListener } from "../types";
+
 /**
  * Constant of all the error types
  * @internal
@@ -59,4 +61,71 @@ export function popupWindow(url: string, windowName: string, win: Window): Windo
   const y = win.top.outerHeight / 2 + win.top.screenY - h / 2;
   const x = win.top.outerWidth / 2 + win.top.screenX - w / 2;
   return win.open(url, windowName, `popup=yes, width=${w}, height=${h}, top=${y}, left=${x}`);
+}
+
+export function arrayMirrorSubscribeListener<T extends Doc>(data: T[], listener?: SubscribeListener<T>) {
+  return {
+    onInitial: (doc: T) => {
+      data.push(doc);
+      if (listener && listener.onInitial) {
+        listener.onAdd(doc);
+      }
+    },
+    onAdd: (doc: T) => {
+      data.push(doc);
+      if (listener && listener.onAdd) {
+        listener.onAdd(doc);
+      }
+    },
+    onChange: (oldDoc: T, newDoc: T) => {
+      const idx = data.findIndex((d) => d.id === oldDoc.id);
+      if (idx > -1) {
+        data[idx] = newDoc;
+      } else {
+        // It is missing for some reason, add it.
+        data.push(newDoc);
+      }
+      if (listener && listener.onChange) {
+        listener.onChange(oldDoc, newDoc);
+      }
+    },
+    onDelete: (doc: T) => {
+      const idx = data.findIndex((d) => d.id === doc.id);
+      if (idx > -1) {
+        data.splice(idx, 1);
+      }
+      if (listener && listener.onDelete) {
+        listener.onDelete(doc);
+      }
+    },
+  };
+}
+
+export function objectMirrorSubscribeListener<T extends Doc>(data: T | undefined, listener?: SubscribeListener<T>) {
+  return {
+    onInitial: (doc: T) => {
+      data = doc;
+      if (listener && listener.onInitial) {
+        listener.onAdd(doc);
+      }
+    },
+    onAdd: (doc: T) => {
+      data = doc;
+      if (listener && listener.onAdd) {
+        listener.onAdd(doc);
+      }
+    },
+    onChange: (oldDoc: T, newDoc: T) => {
+      data = newDoc;
+      if (listener && listener.onChange) {
+        listener.onChange(oldDoc, newDoc);
+      }
+    },
+    onDelete: (doc: T) => {
+      data = undefined;
+      if (listener && listener.onDelete) {
+        listener.onDelete(doc);
+      }
+    },
+  };
 }


### PR DESCRIPTION
Replace alpha `mirrorAll` with `onInitial` in `SubscribeListener`. Also add convenience methods to build mirroring `SubscribeListener`s.

This is more versatile than `mirrorAll` as we can add `SubscribeListener`s for all kinds of structures, incl. React state.