### PR TITLE
Org api

### DIFF
--- a/src/api/collections.ts
+++ b/src/api/collections.ts
@@ -1,3 +1,4 @@
+import { CollectionIdOptions } from "../types";
 import type { API } from "./raw";
 
 /**
@@ -14,23 +15,23 @@ export class CollectionsAPI {
   /**
    * Creates a collection.
    */
-  async create(collectionName: string) {
-    return this.api.collectionsCreate(collectionName);
+  async create(collectionName: string, options: CollectionIdOptions = {}) {
+    return this.api.collectionsCreate(collectionName, options);
   }
 
   /**
    * Drops a collection.
    */
-  async drop(collectionName: string) {
-    return this.api.collectionsDrop(collectionName);
+  async drop(collectionName: string, options: CollectionIdOptions = {}) {
+    return this.api.collectionsDrop(collectionName, options);
   }
 
   /**
    * Lists all collection names.
    * @returns Where `data` is an array of collection names
    */
-  async list() {
-    const res = await this.api.collectionsList();
+  async list(options: CollectionIdOptions = {}) {
+    const res = await this.api.collectionsList(options);
     return res.data;
   }
 }

--- a/src/api/organization.ts
+++ b/src/api/organization.ts
@@ -1,0 +1,37 @@
+import type { Contact, SubscribeListener } from "../types";
+import type { API } from "./raw";
+
+/**
+ * The class that encapsulates the organization API
+ * @internal
+ */
+export class OrganizationAPI {
+  private api: API;
+
+  constructor(api: API) {
+    this.api = api;
+  }
+
+  /**
+   * Gets the organization info for a given ID or handle.
+   * @param query - The ID or handle of the organization, requires one of the two.
+   */
+  async getOrg(query: { orgId?: string; handle?: string } = {}) {
+    const res = await this.api.organizationsGet(query);
+    return res.data;
+  }
+
+  /**
+   * Teams
+   */
+  public teams = {
+    /**
+     * Lists teams
+     * @returns a list of teams user is part of
+     */
+    list: async () => {
+      const res = await this.api.teamsList();
+      return res.data;
+    },
+  };
+}

--- a/src/api/permissions.ts
+++ b/src/api/permissions.ts
@@ -9,6 +9,7 @@ import {
   type PermissionType,
   type SharingNotification,
   type SubscribeListener,
+  CollectionIdOptions,
 } from "../types";
 import { API } from "./raw";
 
@@ -33,8 +34,9 @@ export class PermissionsAPI {
   async create(
     permission: NewPermission,
     notification: SharingNotification = { createNotification: false, sendMessage: SendNotification.NEVER },
+    options: CollectionIdOptions,
   ) {
-    return this.api.permissionsCreate(permission, notification);
+    return this.api.permissionsCreate(permission, notification, options);
   }
 
   /**
@@ -43,13 +45,14 @@ export class PermissionsAPI {
    * @returns All permissions are returned if no options are passed.
    */
   async list(
-    options: {
+    query: {
       collectionName?: string;
       userId?: string;
       type?: PermissionType;
     } = {},
+    options: CollectionIdOptions,
   ) {
-    const res = await this.api.permissionsList(options);
+    const res = await this.api.permissionsList(query, options);
     return res.data;
   }
 
@@ -57,8 +60,8 @@ export class PermissionsAPI {
    * Deletes permission with a given ID
    * @param permissionId - ID of the permission to delete
    */
-  async delete(permissionId: string) {
-    return this.api.permissionsDelete(permissionId);
+  async delete(permissionId: string, options: CollectionIdOptions) {
+    return this.api.permissionsDelete(permissionId, options);
   }
 
   /**
@@ -68,8 +71,13 @@ export class PermissionsAPI {
     /**
      * Creates a link
      */
-    create: async (permission: PermissionTemplate, description: string = "", limit: number = 1) => {
-      const { data: basicLink } = await this.api.linksCreate(permission, description, limit);
+    create: async (
+      permission: PermissionTemplate,
+      description: string = "",
+      limit: number = 1,
+      options: CollectionIdOptions,
+    ) => {
+      const { data: basicLink } = await this.api.linksCreate(permission, description, limit, options);
       return { url: this.linkUri + basicLink.id, ...basicLink };
     },
 
@@ -77,12 +85,13 @@ export class PermissionsAPI {
      * Lists links
      */
     list: async (
-      options: {
+      query: {
         collectionName?: string;
         type?: PermissionType;
       } = {},
+      options: CollectionIdOptions,
     ): Promise<Link[]> => {
-      const { data: basicLinks } = await this.api.linksList(options);
+      const { data: basicLinks } = await this.api.linksList(query, options);
       let links: Link[] = [];
       for (let l of basicLinks) {
         links.push({ url: this.linkUri + l.id, ...l });
@@ -95,14 +104,15 @@ export class PermissionsAPI {
      * @returns an unsubscribe function
      */
     subscribe: async (
-      options: {
+      query: {
         collectionName?: string;
         type?: PermissionType;
       } = {},
+      options: CollectionIdOptions,
       listener: SubscribeListener<Link>,
     ) => {
       if (listener.onInitial) {
-        const links = await this.links.list(options);
+        const links = await this.links.list(query, options);
         for (const link of links) {
           listener.onInitial({ url: this.linkUri + link.id, ...link });
         }
@@ -127,7 +137,7 @@ export class PermissionsAPI {
           );
         };
       }
-      return this.api.linksSubscribe(options, newListener);
+      return this.api.linksSubscribe(query, options, newListener);
     },
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { Auth } from "./auth";
 import { bazaarUri } from "./constants";
 import type { BazaarOptions, CollectionOptions, Doc, LoginType } from "./types";
 import { NotificationsAPI } from "./api/notifications";
+import { OrganizationAPI } from "./api/organization";
 
 /**
  * Types of errors that can return from the API
@@ -85,6 +86,11 @@ export class BazaarApp {
    */
   social: SocialAPI;
 
+  /**
+   * Access to the organizational API
+   */
+  org: SocialAPI;
+
   constructor(options: BazaarOptions) {
     if (!options.bazaarUri) {
       options.bazaarUri = bazaarUri;
@@ -133,6 +139,7 @@ export class BazaarApp {
     this.permissions = new PermissionsAPI(this.api, options.bazaarUri);
     this.notifications = new NotificationsAPI(this.api);
     this.social = new SocialAPI(this.api);
+    this.org = new OrganizationAPI(this.api);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ export { OrderByType, PermissionType, LoginType, SendNotification } from "./type
 export type {
   User,
   Contact,
+  Team,
+  Org,
   Permission,
   NewPermission,
   PermissionTemplate,

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ export class BazaarApp {
   /**
    * Access to the organizational API
    */
-  org: SocialAPI;
+  org: OrganizationAPI;
 
   constructor(options: BazaarOptions) {
     if (!options.bazaarUri) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -326,38 +326,50 @@ export type Contact = {
   user: User;
 };
 
+export type Org = {
+  id: string;
+  name: string;
+  handle: string;
+};
+/**
+ *
+ */
+export type Team = {
+  id: string;
+  name: string;
+  ownerType: "user" | "org";
+  owner: string; // The one that pays. Can be user or org ID, depending on type.
+  primary: boolean; // Specify it as the primary user or org team. Cannot be deleted. User team cannot be modified.
+  admins: string[]; // IDs with read/write access to resources & modify team
+  members: string[]; // IDs with read/write access to resouces
+};
+
 export type CollectionOptions = {
   onCreate?: () => Promise<void>;
-  userId?: string;
+  teamId?: string; // Specify the team the collection belongs to. Defaults to own team/user
+  userId?: string; // An alias for teamId. Cannot be used with teamId.
 };
 
 /**
- * Options for several methods in {@link API}
+ * Options that helps identify the collection. Used for several methods in {@link API}
+ * Note: userId is removed since it is just an alias for teamId
  */
-export type CollectionCommonOptions = {
-  /** An optional user ID of the owner of the collection to read. Defaults to own ID. */
-  userId?: string;
+export type CollectionIdOptions = Omit<CollectionOptions, "onCreate" | "userId">;
+
+/**
+ * Options for {@link API.collectionSubscribeAll} and {@link API.collectionDeleteAll}
+ */
+export type CollectionQueryOptions = CollectionIdOptions & {
+  filter?: FilterObject;
 };
 
 /**
  * Options for {@link API.collectionGetAll}
  */
-export type CollectionGetAllOptions = {
+export type CollectionGetAllOptions = CollectionQueryOptions & {
   /** An optional start offset. Default is 0 (inclusive). */
   startOffset?: number;
   /** An optional end offset. Default is `null` (exclusive). */
   endOffset?: number;
   orderBy?: OrderBy;
-  filter?: FilterObject;
-  /** An optional user ID of the owner of the collection to read. Defaults to own ID. */
-  userId?: string;
-};
-
-/**
- * Options for {@link API.collectionSubscribeAll} and {@link API.collectionDeleteAll}
- */
-export type CollectionCommonAllOptions = {
-  filter?: FilterObject;
-  /** An optional user ID of the owner of the collection to read. Defaults to own ID. */
-  userId?: string;
 };


### PR DESCRIPTION
Adds org/team API introduced in https://github.com/bzr-sys/bazaar-server/pull/177

Also:
- Collections API now takes a `teamId` option
- Lazy collection creation now works for any DB we have permissions for
- Update permissions/links API to take a `teamId` (might break some existing code)
- Clean up some types