### PR TITLE
Make create context async to future-proof

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -243,7 +243,7 @@ export class BazaarApp {
     return new CollectionAPI<T>(this.api, collectionName, collectionOptions);
   }
 
-  createContext(options: ContextOptions): BazaarContext {
+  async createContext(options: ContextOptions) {
     return new BazaarContext(this.api, this.bazaarUri, options);
   }
 }


### PR DESCRIPTION
We probably will want to run migrations when creating the context. Now we do it on every request and that is not acceptable.